### PR TITLE
Misc fixes: `--show-lineup` and `--norefresh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install gracenote2epg[full]
 pip install gracenote2epg
 
 # Alternative: Install from GitHub
-pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.4"
+pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.5"
 ```
 
 ### 📦 Development Installation

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,14 @@ All notable changes to gracenote2epg are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.5] - 2025-09-06
+
+### Fixed
+- **Show Lineup**:
+   - Fix `--show-lineup` where timestamp was fixed leading to non-functional URL.
+   - Refactor display functions to eliminate code duplication.
+- **No Refresh**: Fix `--norefresh` where `'refresh_hours == 0'` was not handled leading to first 3h guide block being downloaded instead of using the cache as expected.
+
 ## [1.5.4] - 2025-08-27
 
 ### Fixed

--- a/docs/development.md
+++ b/docs/development.md
@@ -284,7 +284,7 @@ The project uses a centralized version management system:
 # gracenote2epg/__init__.py
 
 # Example:
-__version__ = "1.5.4"
+__version__ = "1.5.5"
 
 # setup.py will automatically pick up the new version
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,10 +24,10 @@ pip install gracenote2epg[translations]  # Translation support only
 #### Latest Stable Release
 ```bash
 # Install latest stable release from GitHub
-pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.4"
+pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.5"
 
 # Basic installation from GitHub
-pip install "gracenote2epg @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.4"
+pip install "gracenote2epg @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.5"
 ```
 
 #### Latest Development Version
@@ -51,13 +51,13 @@ pip install .        # Basic installation
 ### Method 4: Manual Installation (Source Distribution)
 ```bash
 # Download source from GitHub releases
-wget https://github.com/th0ma7/gracenote2epg/archive/v1.5.4.tar.gz -O gracenote2epg-1.5.4.tar.gz
+wget https://github.com/th0ma7/gracenote2epg/archive/v1.5.5.tar.gz -O gracenote2epg-1.5.5.tar.gz
 
 # Install into /usr/local/
-sudo tar -xzf gracenote2epg-1.5.4.tar.gz -C /usr/local/
+sudo tar -xzf gracenote2epg-1.5.5.tar.gz -C /usr/local/
 
 # Create a generic gracenote2epg symbolic link
-sudo ln -sf /usr/local/gracenote2epg-1.5.4 /usr/local/gracenote2epg
+sudo ln -sf /usr/local/gracenote2epg-1.5.5 /usr/local/gracenote2epg
 
 # Make tv_grab_gracenote2epg available in /usr/local/bin
 sudo ln -sf /usr/local/gracenote2epg/tv_grab_gracenote2epg /usr/local/bin
@@ -120,7 +120,7 @@ tv_grab_gracenote2epg --version
 sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install gracenote2epg[full]'
 
 # Install a specific version of gracenote2epg from Pypi in TVheadend environment
-sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full]==1.5.4"'
+sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full]==1.5.5"'
 
 # Install latest git snapshot
 sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git"'
@@ -169,7 +169,7 @@ python -m gracenote2epg --version    # Module execution
 ```bash
 # Check if package is installed
 pip list | grep gracenote2epg
-# Expected output: gracenote2epg    1.5.4
+# Expected output: gracenote2epg    1.5.5
 
 # Check version
 tv_grab_gracenote2epg --version

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "1.5.4"
+__version__ = "1.5.5"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/gracenote2epg_parser.py
+++ b/gracenote2epg/gracenote2epg_parser.py
@@ -82,7 +82,7 @@ class GuideParser:
             ):
                 # Determine if it was downloaded or cached
                 time_from_now = grid_time - time.time()
-                if time_from_now < (refresh_hours * 3600):
+                if 0 < time_from_now < (refresh_hours * 3600):
                     # In refresh window - likely downloaded
                     downloaded_count += 1
                 else:


### PR DESCRIPTION
### Fixed
- **Show Lineup**:
   - Fix `--show-lineup` where timestamp was fixed leading to non-functional URL.
   - Refactor display functions to eliminate code duplication.
- **No Refresh**: Fix `--norefresh` where `'refresh_hours == 0'` was not handled leading to first 3h guide block being downloaded instead of using the cache as expected.
